### PR TITLE
URLMatch Regex And Linkify Roll Back

### DIFF
--- a/src/lib/js/manifest-supplychain.js
+++ b/src/lib/js/manifest-supplychain.js
@@ -249,7 +249,7 @@ class ManifestSupplyChain {
 		<details class="sources ${(ft.properties.sources.length === 1 && !(ft.properties.sources[0]) && !(ft.properties.notes)) ? "closed" : ""}" style="background: ${d.details.style.lightColor};">
 			<summary>Notes</summary>
 			<ol>
-				${ft.properties.sources.map(src => src ? `<li><a href="${src}">${src}</a></li>` : "").join("")}
+				${ft.properties.sources.map(src => src ? '<li>'+ManifestUtilities.Linkify(src)+'</li>' : "").join("")}
 				${ManifestUtilities.Linkify(ft.properties.notes)}
 			</ol>
 		</details>`;

--- a/src/lib/js/manifest.js
+++ b/src/lib/js/manifest.js
@@ -500,7 +500,7 @@ class ManifestUtilities {
 		this.markdowner.addExtension(customClassExt);
 	}
 	static Linkify(str) { return str.replaceAll(ManifestUtilities.URLMatch(), '<a href=\"$1\">$1</a>').replaceAll(ManifestUtilities.ManifestMatch(), '<a class="manifest-link" href="$1">$1</a>'); }
-	static URLMatch() { return /(?![^<]*>|[^<>]*<\/(?!(?:p|pre|li|span)>))((https?:)\/\/[a-z0-9&#=.\/\-?_]+)/gi; }
+	static URLMatch() { return /(?![^<]*>|[^<>]*<\/(?!(?:p|pre|li|span)>))(https?:\/\/[^\s"]+)/gi; }
 	static ManifestMatch() { return /(?![^<]*>|[^<>]*<\/(?!(?:p|pre|li|span)>))((manifest?:)\/\/[a-z0-9&#=.\/\-?_]+)/gi; }
 	static RemToPixels(rem) { return rem * parseFloat(getComputedStyle(document.documentElement).fontSize); }
 }


### PR DESCRIPTION
The previous URLMatch regular expression only accounted for a single "+" in the URL. The new expression allows for multiple "?" and "+".

In addition the pull request from this branch rolls back the Linkify edit made in master branch. Our goal was not to remove Linkify but make it better.